### PR TITLE
fix 3.4.9-tag for Ubuntu 18.04

### DIFF
--- a/build_config/catkin/multisense_lib/package.xml_
+++ b/build_config/catkin/multisense_lib/package.xml_
@@ -10,10 +10,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>libpng12-dev</build_depend>
+  <build_depend>libpng-dev</build_depend>
   <build_depend>cv_bridge</build_depend>
 
-  <run_depend>libpng12-dev</run_depend>
+  <run_depend>libpng-dev</run_depend>
   <run_depend>cv_bridge</run_depend>
 
 </package>

--- a/multisense_lib/package.xml
+++ b/multisense_lib/package.xml
@@ -10,10 +10,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>libpng12-dev</build_depend>
+  <build_depend>libpng-dev</build_depend>
   <build_depend>cv_bridge</build_depend>
 
-  <run_depend>libpng12-dev</run_depend>
+  <run_depend>libpng-dev</run_depend>
   <run_depend>cv_bridge</run_depend>
 
 </package>

--- a/multisense_ros/src/raw_snapshot.cpp
+++ b/multisense_ros/src/raw_snapshot.cpp
@@ -168,7 +168,7 @@ public:
 
 private:
 
-    static const double SCAN_COLLECT_TIMEOUT = 20.0; // seconds
+    const double SCAN_COLLECT_TIMEOUT = 20.0; // seconds
 
     bool motion_started_;
     ros::CallbackQueue queue_;


### PR DESCRIPTION
- `libpng12-dev` -> `libpng12` for Ubuntu18.04
- Fix g++ compile error